### PR TITLE
Fix MQTTReader Dependency Injection

### DIFF
--- a/SMAIAXConnector/Messaging/MessagingBackgroundService.cs
+++ b/SMAIAXConnector/Messaging/MessagingBackgroundService.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.Hosting;
-
-namespace SMAIAXConnector.Messaging;
+﻿namespace SMAIAXConnector.Messaging;
 
 public class MessagingBackgroundService(IMqttReader mqttReader) : BackgroundService
 {

--- a/SMAIAXConnector/Messaging/MqttReader.cs
+++ b/SMAIAXConnector/Messaging/MqttReader.cs
@@ -8,7 +8,7 @@ using SMAIAXConnector.Domain.Interfaces;
 
 namespace SMAIAXConnector.Messaging;
 
-public class MqttReader(IOptions<MqttSettings> mqttSettings, IMeasurementRepository measurementRepository) : IMqttReader
+public class MqttReader(IOptions<MqttSettings> mqttSettings, IServiceProvider services) : IMqttReader
 {
     private IMqttClient? _mqttClient;
 
@@ -55,6 +55,8 @@ public class MqttReader(IOptions<MqttSettings> mqttSettings, IMeasurementReposit
             // Send to database
             if (measurement != null)
             {
+                using var scope = services.CreateScope();
+                var measurementRepository = scope.ServiceProvider.GetRequiredService<IMeasurementRepository>();
                 await measurementRepository.AddMeasurementAsync(measurement);
             }
         };

--- a/SMAIAXConnector/SMAIAXConnector.csproj
+++ b/SMAIAXConnector/SMAIAXConnector.csproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
@@ -25,11 +24,4 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0-rc.2" />
     </ItemGroup>
-
-    <ItemGroup>
-      <None Update="appsettings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-
 </Project>

--- a/SMAIAXConnector/appsettings.Development.json
+++ b/SMAIAXConnector/appsettings.Development.json
@@ -8,6 +8,6 @@
     "ClientId": "SMAIAX-Connector",
     "Username": "user",
     "Password": "password",
-    "Topic": "test"
+    "Topic": "smartmeter/070dec95-56bb-4154-a2c4-c26faf9fff4d"
   }
 }

--- a/SMAIAXConnector/appsettings.json
+++ b/SMAIAXConnector/appsettings.json
@@ -8,6 +8,6 @@
     "ClientId": "SMAIAX-Connector",
     "Username": "user",
     "Password": "password",
-    "Topic": "test"
+    "Topic": "smartmeter/070dec95-56bb-4154-a2c4-c26faf9fff4d"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      DOTNET_ENVIRONMENT: DockerDevelopment
     networks:
       - smaiax-backend-network
     


### PR DESCRIPTION
fix(di): resolve scoped service usage in singleton services
- Converted the project from a console application to a worker service.
- Fixed an issue where a scoped service (`IMeasurementRepository`) was being consumed by a singleton (`MqttReader`), violating DI principles.
- Updated appsettings.json and appsettings.Development.json