### PR TITLE
Read from all topics

### DIFF
--- a/SMAIAXConnector/Messaging/MqttReader.cs
+++ b/SMAIAXConnector/Messaging/MqttReader.cs
@@ -28,14 +28,13 @@ public class MqttReader(IOptions<MqttSettings> mqttSettings, IServiceProvider se
         _mqttClient.ConnectedAsync += async e =>
         {
             Console.WriteLine("Connected to MQTT broker!");
-
-            // Subscribe to the topic
+            
             var topicFilter = new MqttTopicFilterBuilder()
-                .WithTopic(mqttSettings.Value.Topic)
+                .WithTopic("#")
                 .Build();
 
             await _mqttClient.SubscribeAsync(topicFilter);
-            Console.WriteLine($"Subscribed to topic {mqttSettings.Value.Topic}");
+            Console.WriteLine($"Subscribed to topic all topics.");
         };
 
         // Handle disconnection

--- a/SMAIAXConnector/Messaging/MqttReader.cs
+++ b/SMAIAXConnector/Messaging/MqttReader.cs
@@ -8,7 +8,7 @@ using SMAIAXConnector.Domain.Interfaces;
 
 namespace SMAIAXConnector.Messaging;
 
-public class MqttReader(IOptions<MqttSettings> mqttSettings, IServiceProvider services) : IMqttReader
+public class MqttReader(IOptions<MqttSettings> mqttSettings, IServiceProvider services, ILogger<MqttReader> logger) : IMqttReader
 {
     private IMqttClient? _mqttClient;
 
@@ -27,20 +27,20 @@ public class MqttReader(IOptions<MqttSettings> mqttSettings, IServiceProvider se
         // Connect to MQTT broker
         _mqttClient.ConnectedAsync += async e =>
         {
-            Console.WriteLine("Connected to MQTT broker!");
+            logger.LogInformation("Connected to MQTT broker!");
             
             var topicFilter = new MqttTopicFilterBuilder()
                 .WithTopic("#")
                 .Build();
 
             await _mqttClient.SubscribeAsync(topicFilter);
-            Console.WriteLine($"Subscribed to topic all topics.");
+            logger.LogInformation("Subscribed to all topics.");
         };
 
         // Handle disconnection
         _mqttClient.DisconnectedAsync += e =>
         {
-            Console.WriteLine("Disconnected from MQTT broker.");
+            logger.LogInformation("Disconnected from MQTT broker.");
             return Task.CompletedTask;
         };
 
@@ -49,8 +49,8 @@ public class MqttReader(IOptions<MqttSettings> mqttSettings, IServiceProvider se
         {
             var message = Encoding.UTF8.GetString(e.ApplicationMessage.PayloadSegment.ToArray());
             var measurement = JsonConvert.DeserializeObject<Measurement>(message);
-            Console.WriteLine($"Received Measurement: {measurement}");
-
+            logger.LogDebug("Received Measurement: {Measurement}", measurement);
+            
             // Send to database
             if (measurement != null)
             {
@@ -69,7 +69,7 @@ public class MqttReader(IOptions<MqttSettings> mqttSettings, IServiceProvider se
         if (_mqttClient != null && _mqttClient.IsConnected)
         {
             await _mqttClient.DisconnectAsync();
-            Console.WriteLine("Disconnected from MQTT broker.");
+            logger.LogInformation("Disconnected from MQTT broker.");
         }
     }
 }

--- a/SMAIAXConnector/Messaging/MqttSettings.cs
+++ b/SMAIAXConnector/Messaging/MqttSettings.cs
@@ -7,5 +7,4 @@ public class MqttSettings
     public required string ClientId { get; init; }
     public required string Username { get; init; }
     public required string Password { get; init; }
-    public required string Topic { get; init; }
 }

--- a/SMAIAXConnector/appsettings.Development.json
+++ b/SMAIAXConnector/appsettings.Development.json
@@ -7,7 +7,6 @@
     "Port": 1883,
     "ClientId": "SMAIAX-Connector",
     "Username": "user",
-    "Password": "password",
-    "Topic": "smartmeter/070dec95-56bb-4154-a2c4-c26faf9fff4d"
+    "Password": "password"
   }
 }

--- a/SMAIAXConnector/appsettings.DockerDevelopment.json
+++ b/SMAIAXConnector/appsettings.DockerDevelopment.json
@@ -7,7 +7,6 @@
     "Port": 1883,
     "ClientId": "SMAIAX-Connector",
     "Username": "user",
-    "Password": "password",
-    "Topic": "smartmeter/070dec95-56bb-4154-a2c4-c26faf9fff4d"
+    "Password": "password"
   }
 }

--- a/SMAIAXConnector/appsettings.json
+++ b/SMAIAXConnector/appsettings.json
@@ -7,7 +7,6 @@
     "Port": 1883,
     "ClientId": "SMAIAX-Connector",
     "Username": "user",
-    "Password": "password",
-    "Topic": "smartmeter/070dec95-56bb-4154-a2c4-c26faf9fff4d"
+    "Password": "password"
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `SMAIAXConnector` project to improve logging and simplify the MQTT subscription configuration. The most important changes include adding a logger to the `MqttReader` class, replacing `Console.WriteLine` statements with logger calls, and removing the topic configuration from the settings files.

### Improvements to logging:

* [`SMAIAXConnector/Messaging/MqttReader.cs`](diffhunk://#diff-5563b4214360232733dd88170d32c75a8fe226881d39ee60c38ddb812298766cL11-R11): Added `ILogger<MqttReader>` parameter to the `MqttReader` constructor and replaced `Console.WriteLine` statements with appropriate logger calls such as `LogInformation` and `LogDebug`. [[1]](diffhunk://#diff-5563b4214360232733dd88170d32c75a8fe226881d39ee60c38ddb812298766cL11-R11) [[2]](diffhunk://#diff-5563b4214360232733dd88170d32c75a8fe226881d39ee60c38ddb812298766cL30-R43) [[3]](diffhunk://#diff-5563b4214360232733dd88170d32c75a8fe226881d39ee60c38ddb812298766cL53-R52) [[4]](diffhunk://#diff-5563b4214360232733dd88170d32c75a8fe226881d39ee60c38ddb812298766cL73-R72)

### Simplification of MQTT subscription configuration:

* [`SMAIAXConnector/Messaging/MqttReader.cs`](diffhunk://#diff-5563b4214360232733dd88170d32c75a8fe226881d39ee60c38ddb812298766cL30-R43): Changed the subscription topic to subscribe to all topics by using `"#"` instead of a specific topic from the settings.
* [`SMAIAXConnector/Messaging/MqttSettings.cs`](diffhunk://#diff-f56314d062e1c793fa520dcc2a6acf79ab90b7ede3c6b13cf44f4055ea6713a2L10): Removed the `Topic` property from the `MqttSettings` class.
* `SMAIAXConnector/appsettings.Development.json`, `SMAIAXConnector/appsettings.DockerDevelopment.json`, `SMAIAXConnector/appsettings.json`: Removed the `Topic` configuration from the settings files. [[1]](diffhunk://#diff-f1585bc8dd599fdefdc413ad5c4c104470ab4e77b2f07e06591f676b24c53f81L10-R10) [[2]](diffhunk://#diff-6b5a87dae5856829dab6dd4a6103f09779b26cd21e8aec7eb2a0d15346730484L10-R10) [[3]](diffhunk://#diff-2dbccd8a2802f6d27a00db0adb96c9fab1b2b9a822cccaa8120a9021b9bc1192L10-R10)